### PR TITLE
remove `tool` from `[tool.isort]`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,6 @@ ignore=ANN101,D107,W503
 exclude=.cache,.venv,.git,constants.py,__pycache__
 application_import_names=arthur
 
-[tool.isort]
+[isort]
 profile = "black"
 multi_line_output = 5

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ exclude=.cache,.venv,.git,constants.py,__pycache__
 application_import_names=arthur
 
 [isort]
-profile = "black"
+profile = black
 multi_line_output = 5


### PR DESCRIPTION
isort does not recognise `[tool.isort]` as a section for it in the tox.ini file. 
It is only recognised as `[tool.isort]` in a pyproject.toml file, and `[isort]` in tox.ini

Isort docs: https://pycqa.github.io/isort/docs/configuration/config_files.html
