### PR TITLE
Refactor workflows, add concurrency options, separate build and deploy

### DIFF
--- a/.github/workflows/lint-build-deploy.yaml
+++ b/.github/workflows/lint-build-deploy.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -153,3 +156,31 @@ jobs:
               namespaces/default/king-arthur/deployment.yaml
           images: 'ghcr.io/python-discord/king-arthur:${{ steps.sha_tag.outputs.tag }}'
           kubectl-version: 'latest'
+
+  artifact:
+    name: Generate Artifact
+    if: always() && github.event_name == 'pull_request'
+    needs: [lint, build, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      # Prepare the Pull Request Payload artifact. If this fails, we
+      # we fail silently using the `continue-on-error` option. It's
+      # nice if this succeeds, but if it fails for any reason, it
+      # does not mean that our lint-test checks failed.
+      - name: Prepare Pull Request Payload artifact
+        id: prepare-artifact
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+
+      # This only makes sense if the previous step succeeded. To
+      # get the original outcome of the previous step before the
+      # `continue-on-error` conclusion is applied, we use the
+      # `.outcome` value. This step also fails silently.
+      - name: Upload a Build Artifact
+        if: always() && steps.prepare-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: pull-request-payload
+          path: pull_request_payload.json

--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -1,20 +1,16 @@
+# Sends a status embed to a discord webhook
+
 name: Status Embed
 
 on:
   workflow_run:
     workflows:
-      - Lint
-      - Build & Push
+      - Lint, Build & Deploy
     types:
       - completed
 
 jobs:
   status_embed:
-    if: >-
-      (github.event.workflow_run.name == 'Build & Push' && github.event.workflow_run.conclusion != 'skipped') ||
-      github.event.workflow_run.event == 'pull_request' ||
-      github.event.workflow_run.conclusion == 'failure' ||
-      github.event.workflow_run.conclusion == 'cancelled'
     name:  Send Status Embed to Discord
     runs-on: ubuntu-latest
 
@@ -44,7 +40,7 @@ jobs:
       # more information and we can fine tune when we actually want
       # to send an embed.
       - name: GitHub Actions Status Embed for Discord
-        uses: SebastiaanZ/github-status-embed-for-discord@v0.2.1
+        uses: SebastiaanZ/github-status-embed-for-discord@v0.3.0
         with:
           # Our GitHub Actions webhook
           webhook_id: '784184528997842985'


### PR DESCRIPTION
workflow trigger copied from python-discord/bot
concurrency options added to all workflows
also fixes status embed