### PR TITLE
Ensure compatibility with black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ application_import_names=arthur
 
 [isort]
 profile=black
-multi_line_output=5
+line_length=100


### PR DESCRIPTION
the black profile already sets this variable, and it sets it to a different setting from what was set
see the docs here: https://pycqa.github.io/isort/docs/configuration/profiles.html

the black profile sets the below settings
    multi_line_output: 3
    include_trailing_comma: True
    force_grid_wrap: 0
    use_parentheses: True
    ensure_newline_before_comments: True
    line_length: 88