### PR TITLE
Use python-poetry-base Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,16 @@
-FROM --platform=linux/amd64 python:3.10-slim
-
-# Set pip to have no saved cache
-ENV PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    POETRY_VERSION=1.2.0 \
-    POETRY_HOME="/opt/poetry" \
-    POETRY_VIRTUALENVS_IN_PROJECT=true \
-    POETRY_NO_INTERACTION=1 \
-    INSTALL_DIR="/opt/dependencies" \
-    APP_DIR="/app"
-
-ENV PATH="$POETRY_HOME/bin:/$INSTALL_DIR/.venv/bin:$PATH"
-
-RUN apt-get update \
-  && apt-get -y upgrade \
-  && apt-get install --no-install-recommends -y curl \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sSL https://install.python-poetry.org | python
+FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.10-slim
 
 # Install project dependencies
-WORKDIR $INSTALL_DIR
+WORKDIR /app
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-dev
-
-# Define Git SHA build argument
-ARG git_sha="development"
+RUN poetry install --without dev
 
 # Set Git SHA environment variable for Sentry
+ARG git_sha="development"
 ENV GIT_SHA=$git_sha
 
 # Copy the source code in last to optimize rebuilding the image
-WORKDIR $APP_DIR
 COPY . .
 
-ENTRYPOINT ["python3"]
+ENTRYPOINT ["poetry", "run", "python"]
 CMD ["-m", "arthur"]


### PR DESCRIPTION
Use chrislovering/python-poetry-base as the base image for docker builds, to centralize poetry installation and configuration.

This is part of a larger push across all python-discord projects.