### PR TITLE
Grafana team sync

### DIFF
--- a/arthur/apis/github/__init__.py
+++ b/arthur/apis/github/__init__.py
@@ -1,0 +1,6 @@
+from .teams import GithubTeamNotFoundError, list_team_members
+
+__all__ = (
+    "GithubTeamNotFoundError",
+    "list_team_members",
+)

--- a/arthur/apis/github/teams.py
+++ b/arthur/apis/github/teams.py
@@ -1,0 +1,22 @@
+import aiohttp
+
+from arthur.config import CONFIG
+
+HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "Authorization": f"Bearer {CONFIG.github_token.get_secret_value()}",
+}
+BASE_URL = "https://api.github.com"
+
+
+class GithubTeamNotFoundError(aiohttp.ClientResponseError):
+    """Raised when a github team could not be found."""
+
+
+async def list_team_members(team_slug: str, session: aiohttp.ClientSession) -> list[dict[str, str]]:
+    """List all Github teams."""
+    endpoint = BASE_URL + f"/orgs/{CONFIG.github_org}/teams/{team_slug}/members"
+    async with session.get(endpoint, headers=HEADERS) as response:
+        response.raise_for_status()
+        return await response.json()

--- a/arthur/apis/grafana/__init__.py
+++ b/arthur/apis/grafana/__init__.py
@@ -1,0 +1,8 @@
+from .teams import add_user_to_team, get_all_users, list_team_members, list_teams
+
+__all__ = (
+    "add_user_to_team",
+    "get_all_users",
+    "list_team_members",
+    "list_teams",
+)

--- a/arthur/apis/grafana/__init__.py
+++ b/arthur/apis/grafana/__init__.py
@@ -1,8 +1,15 @@
-from .teams import add_user_to_team, get_all_users, list_team_members, list_teams
+from .teams import (
+    add_user_to_team,
+    get_all_users,
+    list_team_members,
+    list_teams,
+    remove_user_from_team,
+)
 
 __all__ = (
     "add_user_to_team",
     "get_all_users",
     "list_team_members",
     "list_teams",
+    "remove_user_from_team",
 )

--- a/arthur/apis/grafana/teams.py
+++ b/arthur/apis/grafana/teams.py
@@ -1,6 +1,5 @@
 import aiohttp
 
-from arthur import logger
 from arthur.config import CONFIG
 
 AUTH_HEADER = {"Authorization": f"Bearer {CONFIG.grafana_token.get_secret_value()}"}
@@ -10,9 +9,8 @@ async def list_teams(session: aiohttp.ClientSession) -> dict[str, str]:
     """List all Grafana teams."""
     endpoint = CONFIG.grafana_url + "/api/teams/search"
     async with session.get(endpoint, headers=AUTH_HEADER) as response:
+        response.raise_for_status()
         teams = await response.json()
-        if not response.ok:
-            logger.error(teams)
     return teams["teams"]
 
 
@@ -20,10 +18,8 @@ async def list_team_members(team_id: int, session: aiohttp.ClientSession) -> lis
     """List all members within a team."""
     endpoint = CONFIG.grafana_url + f"/api/teams/{team_id}/members"
     async with session.get(endpoint, headers=AUTH_HEADER) as response:
-        team_members = await response.json()
-        if not response.ok:
-            logger.error(team_members)
-        return team_members
+        response.raise_for_status()
+        return await response.json()
 
 
 async def add_user_to_team(
@@ -35,17 +31,13 @@ async def add_user_to_team(
     endpoint = CONFIG.grafana_url + f"/api/teams/{team_id}/members"
     payload = {"userId": user_id}
     async with session.post(endpoint, headers=AUTH_HEADER, json=payload) as response:
-        add_resp = await response.json()
-        if not response.ok:
-            logger.error(add_resp)
-        return add_resp
+        response.raise_for_status()
+        return await response.json()
 
 
 async def get_all_users(session: aiohttp.ClientSession) -> list[dict[str, str]]:
     """Get a grafana users."""
     endpoint = CONFIG.grafana_url + "/api/org/users/lookup"
     async with session.get(endpoint, headers=AUTH_HEADER) as response:
-        users = await response.json()
-        if not response.ok:
-            logger.error(users)
-        return users
+        response.raise_for_status()
+        return await response.json()

--- a/arthur/apis/grafana/teams.py
+++ b/arthur/apis/grafana/teams.py
@@ -35,6 +35,18 @@ async def add_user_to_team(
         return await response.json()
 
 
+async def remove_user_from_team(
+    user_id: int,
+    team_id: int,
+    session: aiohttp.ClientSession,
+) -> dict[str, str]:
+    """AdRemove a Grafana user from a team."""
+    endpoint = CONFIG.grafana_url + f"/api/teams/{team_id}/members/{user_id}"
+    async with session.delete(endpoint, headers=AUTH_HEADER) as response:
+        response.raise_for_status()
+        return await response.json()
+
+
 async def get_all_users(session: aiohttp.ClientSession) -> list[dict[str, str]]:
     """Get a grafana users."""
     endpoint = CONFIG.grafana_url + "/api/org/users/lookup"

--- a/arthur/apis/grafana/teams.py
+++ b/arthur/apis/grafana/teams.py
@@ -40,7 +40,7 @@ async def remove_user_from_team(
     team_id: int,
     session: aiohttp.ClientSession,
 ) -> dict[str, str]:
-    """AdRemove a Grafana user from a team."""
+    """Remove a Grafana user from a team."""
     endpoint = CONFIG.grafana_url + f"/api/teams/{team_id}/members/{user_id}"
     async with session.delete(endpoint, headers=AUTH_HEADER) as response:
         response.raise_for_status()
@@ -48,7 +48,7 @@ async def remove_user_from_team(
 
 
 async def get_all_users(session: aiohttp.ClientSession) -> list[dict[str, str]]:
-    """Get a grafana users."""
+    """Get all Grafana users."""
     endpoint = CONFIG.grafana_url + "/api/org/users/lookup"
     async with session.get(endpoint, headers=AUTH_HEADER) as response:
         response.raise_for_status()

--- a/arthur/apis/grafana/teams.py
+++ b/arthur/apis/grafana/teams.py
@@ -1,0 +1,51 @@
+import aiohttp
+
+from arthur import logger
+from arthur.config import CONFIG
+
+AUTH_HEADER = {"Authorization": f"Bearer {CONFIG.grafana_token.get_secret_value()}"}
+
+
+async def list_teams(session: aiohttp.ClientSession) -> dict[str, str]:
+    """List all Grafana teams."""
+    endpoint = CONFIG.grafana_url + "/api/teams/search"
+    async with session.get(endpoint, headers=AUTH_HEADER) as response:
+        teams = await response.json()
+        if not response.ok:
+            logger.error(teams)
+    return teams["teams"]
+
+
+async def list_team_members(team_id: int, session: aiohttp.ClientSession) -> list[dict[str, str]]:
+    """List all members within a team."""
+    endpoint = CONFIG.grafana_url + f"/api/teams/{team_id}/members"
+    async with session.get(endpoint, headers=AUTH_HEADER) as response:
+        team_members = await response.json()
+        if not response.ok:
+            logger.error(team_members)
+        return team_members
+
+
+async def add_user_to_team(
+    user_id: int,
+    team_id: int,
+    session: aiohttp.ClientSession,
+) -> dict[str, str]:
+    """Add a Grafana user to a team."""
+    endpoint = CONFIG.grafana_url + f"/api/teams/{team_id}/members"
+    payload = {"userId": user_id}
+    async with session.post(endpoint, headers=AUTH_HEADER, json=payload) as response:
+        add_resp = await response.json()
+        if not response.ok:
+            logger.error(add_resp)
+        return add_resp
+
+
+async def get_all_users(session: aiohttp.ClientSession) -> list[dict[str, str]]:
+    """Get a grafana users."""
+    endpoint = CONFIG.grafana_url + "/api/org/users/lookup"
+    async with session.get(endpoint, headers=AUTH_HEADER) as response:
+        users = await response.json()
+        if not response.ok:
+            logger.error(users)
+        return users

--- a/arthur/config.py
+++ b/arthur/config.py
@@ -12,19 +12,16 @@ class Config(
 ):
     """Configuration for King Arthur."""
 
-    # Discord bot token
     token: pydantic.SecretStr
-
-    # Discord bot prefix
     prefixes: tuple[str, ...] = ("arthur ", "M-x ")
 
-    # Authorised role ID for usage
-    devops_role: int = 409416496733880320
-
-    # Token for authorising with the Cloudflare API
     cloudflare_token: pydantic.SecretStr
+    grafana_url: str = "https://grafana.pythondiscord.com"
+    grafana_token: pydantic.SecretStr
+    github_token: pydantic.SecretStr
+    github_org: str = "python-discord"
 
-    # Guild id
+    devops_role: int = 409416496733880320
     guild_id: int = 267624335836053506
 
 

--- a/arthur/exts/grafana/team_sync.py
+++ b/arthur/exts/grafana/team_sync.py
@@ -1,0 +1,89 @@
+import aiohttp
+import discord
+from discord.ext import commands, tasks
+
+from arthur import logger
+from arthur.apis import github, grafana
+from arthur.bot import KingArthur
+
+
+class GrafanaTeamSync(commands.Cog):
+    """
+    Update Grafana team membership to match Github team membership.
+
+    Grafana team name must match Github team slug exactly.
+    Use `gh api orgs/{org-name}/teams` to get a list of teams in an org
+    """
+
+    def __init__(self, bot: KingArthur) -> None:
+        self.bot = bot
+        self.sync_github_grafana_teams.start()
+
+    async def _sync_teams(self, team: dict[str, str]) -> tuple[int, int]:
+        """
+        Ensure members in github are present in grafana teams.
+
+        Return the number of members missing from teh grafana team, and the number of members added.
+        """
+        github_team_members = {
+            member["login"]
+            for member in await github.list_team_members(team["name"], self.bot.http_session)
+        }
+        grafana_team_members = {
+            member["login"]
+            for member in await grafana.list_team_members(team["id"], self.bot.http_session)
+            if member.get("auth_module") == "oauth_github"
+        }
+
+        missing_members = github_team_members - grafana_team_members
+        grafana_users = await grafana.get_all_users(self.bot.http_session)
+        added_members = set()
+        for grafana_user in grafana_users:
+            if grafana_user["login"] not in missing_members:
+                continue
+            await grafana.add_user_to_team(
+                grafana_user["userId"],
+                team["id"],
+                self.bot.http_session,
+            )
+            added_members.add(grafana_user["login"])
+        return len(missing_members), len(added_members)
+
+    @tasks.loop(hours=12)
+    async def sync_github_grafana_teams(self, channel: discord.TextChannel | None = None) -> None:
+        """Update Grafana team membership to match Github team membership."""
+        grafana_teams = await grafana.list_teams(self.bot.http_session)
+        for team in grafana_teams:
+            logger.debug(f"Processing {team['name']}")
+            try:
+                missing, added = await self._sync_teams(team)
+            except aiohttp.ClientResponseError as e:
+                logger.error(e)
+                if channel:
+                    await channel.send(e)
+                continue
+
+            if channel and missing:
+                await channel.send(
+                    f"Found {missing} users not in the {team['name']} grafana team, added {added} of them."
+                )
+
+    @sync_github_grafana_teams.error
+    async def on_task_error(self, error: Exception) -> None:
+        """Ensure task errors are output."""
+        logger.error(error)
+
+    @commands.group(name="grafana", aliases=("graf",), invoke_without_command=True)
+    async def grafana_group(self, ctx: commands.Context) -> None:
+        """Commands for working with grafana API."""
+        await ctx.send_help(ctx.command)
+
+    @grafana_group.command(name="sync")
+    async def sync_teams(self, ctx: commands.Context) -> None:
+        """Sync Grafana & Github teams now."""
+        await self.sync_github_grafana_teams(ctx.channel)
+
+
+async def setup(bot: KingArthur) -> None:
+    """Add cog to bot."""
+    await bot.add_cog(GrafanaTeamSync(bot))

--- a/arthur/exts/grafana/team_sync.py
+++ b/arthur/exts/grafana/team_sync.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import aiohttp
 import discord
 from discord.ext import commands, tasks
@@ -5,6 +7,22 @@ from discord.ext import commands, tasks
 from arthur import logger
 from arthur.apis import github, grafana
 from arthur.bot import KingArthur
+
+
+@dataclass(frozen=True)
+class MissingMembers:
+    """Number of members that were missing from the Grafana team, and how many could be added."""
+
+    count: int
+    successfully_added: int
+
+
+@dataclass(frozen=True)
+class SyncFigures:
+    """Figures related to a single sync members task run."""
+
+    added: MissingMembers
+    removed: int
 
 
 class GrafanaTeamSync(commands.Cog):
@@ -19,11 +37,33 @@ class GrafanaTeamSync(commands.Cog):
         self.bot = bot
         self.sync_github_grafana_teams.start()
 
-    async def _sync_teams(self, team: dict[str, str]) -> tuple[int, int]:
+    async def _add_missing_members(
+        self, grafana_team_id: int, github_team_members: set[str], grafana_team_members: set[str]
+    ) -> MissingMembers:
         """
-        Ensure members in github are present in grafana teams.
+        Adds members to the Grafana team if they're in the Github team and not already present.
 
-        Return the number of members missing from teh grafana team, and the number of members added.
+        Returns the number of missing members, and the number of members it could actually add.
+        """
+        missing_members = github_team_members - grafana_team_members
+        grafana_users = await grafana.get_all_users(self.bot.http_session)
+        added_members = set()
+        for grafana_user in grafana_users:
+            if grafana_user["login"] not in missing_members:
+                continue
+            await grafana.add_user_to_team(
+                grafana_user["userId"],
+                grafana_team_id,
+                self.bot.http_session,
+            )
+            added_members.add(grafana_user["login"])
+        return MissingMembers(count=len(missing_members), successfully_added=len(added_members))
+
+    async def _sync_teams(self, team: dict[str, str]) -> SyncFigures:
+        """
+        Ensure members in Github are present in Grafana teams.
+
+        Return the number of members missing from the Grafana team, and the number of members added.
         """
         github_team_members = {
             member["login"]
@@ -35,19 +75,14 @@ class GrafanaTeamSync(commands.Cog):
             if member.get("auth_module") == "oauth_github"
         }
 
-        missing_members = github_team_members - grafana_team_members
-        grafana_users = await grafana.get_all_users(self.bot.http_session)
-        added_members = set()
-        for grafana_user in grafana_users:
-            if grafana_user["login"] not in missing_members:
-                continue
-            await grafana.add_user_to_team(
-                grafana_user["userId"],
-                team["id"],
-                self.bot.http_session,
-            )
-            added_members.add(grafana_user["login"])
-        return len(missing_members), len(added_members)
+        added_members = await self._add_missing_members(
+            team["id"],
+            github_team_members,
+            grafana_team_members,
+        )
+        removed_members = 0  # TODO Actually remove members who shouldn't be present.
+
+        return SyncFigures(added=added_members, removed=removed_members)
 
     @tasks.loop(hours=12)
     async def sync_github_grafana_teams(self, channel: discord.TextChannel | None = None) -> None:
@@ -56,16 +91,17 @@ class GrafanaTeamSync(commands.Cog):
         for team in grafana_teams:
             logger.debug(f"Processing {team['name']}")
             try:
-                missing, added = await self._sync_teams(team)
+                figures = await self._sync_teams(team)
             except aiohttp.ClientResponseError as e:
                 logger.error(e)
                 if channel:
                     await channel.send(e)
                 continue
 
-            if channel and missing:
+            if channel:
                 await channel.send(
-                    f"Found {missing} users not in the {team['name']} grafana team, added {added} of them."
+                    f"Found {figures.added.count} users not in the {team['name']} Grafana team, added {figures.added.successfully_added} of them. "
+                    f"{figures.removed} members were found in the Grafana team who shouldn't be, and were removed."
                 )
 
     @sync_github_grafana_teams.error

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     restart: "no"
     build: .
     volumes:
-      - .:/bot:ro
+      - .:/app:ro
     tty: true
     env_file:
       - .env


### PR DESCRIPTION
This will keep grafana team membership up to date with github team membership.

It assumes that the grafana team has the same name as the GitHub team.

The new secrets are already present in production for this.