### PR TITLE
Paginate pod logs instead of truncating them

### DIFF
--- a/arthur/config.py
+++ b/arthur/config.py
@@ -27,6 +27,7 @@ class Config(
     guild_id: int = 267624335836053506
     devops_channel_id: int = 675756741417369640
     sentry_dsn: str = ""
+    trashcan: str = "<:trashcan:637136429717389331>"
 
 
 GIT_SHA = environ.get("GIT_SHA", "development")

--- a/arthur/pagination.py
+++ b/arthur/pagination.py
@@ -1,0 +1,63 @@
+from collections.abc import Sequence
+
+import discord
+from discord.ext.commands import Context
+from pydis_core.utils.pagination import LinePaginator as _LinePaginator, PaginationEmojis
+
+from arthur.config import CONFIG
+
+
+class LinePaginator(_LinePaginator):
+    """
+    A class that aids in paginating code blocks for Discord messages.
+
+    See the super class's docs for more info.
+    """
+
+    @classmethod
+    async def paginate(
+        cls,
+        lines: list[str],
+        ctx: Context | discord.Interaction,
+        embed: discord.Embed,
+        prefix: str = "",
+        suffix: str = "",
+        max_lines: int | None = None,
+        max_size: int = 500,
+        scale_to_size: int = 4000,
+        restrict_to_user: discord.User | None = None,
+        timeout: int = 300,
+        footer_text: str | None = None,
+        url: str | None = None,
+        allowed_roles: Sequence[int] | None = None,
+        *,
+        reply: bool = False,
+        empty: bool = True,
+        exception_on_empty_embed: bool = False,
+    ) -> discord.Message | None:
+        """
+        Use a paginator and set of reactions to provide pagination over a set of lines.
+
+        Acts as a wrapper for the super class' `paginate` method to provide the pagination emojis by default.
+
+        Consult the super class's `paginate` method for detailed information.
+        """
+        return await super().paginate(
+            pagination_emojis=PaginationEmojis(delete=CONFIG.trashcan),
+            lines=lines,
+            ctx=ctx,
+            embed=embed,
+            prefix=prefix,
+            suffix=suffix,
+            max_lines=max_lines,
+            max_size=max_size,
+            scale_to_size=scale_to_size,
+            empty=empty,
+            restrict_to_user=restrict_to_user,
+            timeout=timeout,
+            footer_text=footer_text,
+            url=url,
+            exception_on_empty_embed=exception_on_empty_embed,
+            reply=reply,
+            allowed_roles=allowed_roles,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ ignore = [
     "S311",
     "SIM102", "SIM108",
     "PD",
-    "PLR6301",
+    "PLR0913", "PLR0917", "PLR6301",
 
     # Rules suggested to be ignored when using ruff format
     "COM812", "D206", "E111", "E114", "E117", "E501", "ISC001", "Q000", "Q001", "Q002", "Q003", "W191",


### PR DESCRIPTION
Truncating original logs can result into important context/logs being burried/removed.

This paginates the logs instead