### PR TITLE
Reduce memory usage in GitHub and LDAP sync

### DIFF
--- a/arthur/apis/directory/keycloak.py
+++ b/arthur/apis/directory/keycloak.py
@@ -2,7 +2,8 @@
 
 from functools import cache
 
-from keycloak import KeycloakAdmin
+from keycloak import KeycloakAdmin, urls_patterns
+from keycloak.exceptions import KeycloakGetError, raise_error_from_response
 
 from arthur.config import CONFIG
 
@@ -79,15 +80,20 @@ async def get_user_github_id(username: str) -> str | None:
 async def all_github_identities() -> dict[str, dict[str, str]]:
     """Fetch Keycloak usernames and their linked GitHub identity information."""
     client = create_client()
-
     users = await client.a_get_users()
     github_identities = {}
 
     for user in users:
-        user_details = await client.a_get_user(user["id"])
-        for ident in user_details["federatedIdentities"]:
+        url = urls_patterns.URL_ADMIN_USER_FEDERATED_IDENTITIES.format(
+            **{"realm-name": client.connection.realm_name, "id": user["id"]}
+        )
+        identities = raise_error_from_response(
+            await client.connection.a_raw_get(url),
+            KeycloakGetError,
+        )
+        for ident in identities:
             if ident["identityProvider"] == "github":
-                github_identities[user_details["username"]] = {
+                github_identities[user["username"]] = {
                     "user_id": ident.get("userId", ""),
                     "user_name": ident.get("userName", ""),
                 }

--- a/arthur/exts/directory/ldap.py
+++ b/arthur/exts/directory/ldap.py
@@ -161,7 +161,7 @@ class LDAP(commands.Cog):
         try:
             logger.info("Syncing users with the LDAP directory.")
 
-            diff, missing_emp, counts = await self.get_user_diff()
+            diff, missing_emp, counts, ldap_users = await self.get_user_diff()
 
             add_users = counts[LDAPSyncAction.ADD]
             remove_users = counts[LDAPSyncAction.REMOVE]
@@ -205,7 +205,7 @@ class LDAP(commands.Cog):
                     user.ldap_user.employee_number if user.ldap_user else str(user.discord_user.id)
                 )
 
-            await self._handle_left_users(handled)
+            await self._handle_left_users(handled, ldap_users)
 
             logger.info("LDAP: Sync complete.")
         except Exception as e:  # noqa: BLE001
@@ -214,10 +214,8 @@ class LDAP(commands.Cog):
                 f":x: LDAP Sync Error: ```python\n{e}```"
             )
 
-    async def _handle_left_users(self, handled: list[int]) -> None:
+    async def _handle_left_users(self, handled: list[int], ldap_users: list[ldap.LDAPUser]) -> None:
         """Handle users that have left the guild and so were not processed."""
-        ldap_users = await ldap.find_users()
-
         for user in ldap_users:
             if user.employee_number is None or user.employee_number in handled:
                 continue
@@ -367,7 +365,7 @@ class LDAP(commands.Cog):
 
     async def get_user_diff(
         self,
-    ) -> tuple[list[DiffedUser], list[ldap.LDAPUser], Counter[LDAPSyncAction]]:
+    ) -> tuple[list[DiffedUser], list[ldap.LDAPUser], Counter[LDAPSyncAction], list[ldap.LDAPUser]]:
         """Calculate and return the diff of users against LDAP from the guild."""
         guild = self.bot.get_guild(CONFIG.guild_id)
         users = await ldap.find_users()
@@ -416,7 +414,7 @@ class LDAP(commands.Cog):
 
         counter = Counter([user.action for user in diff])
 
-        return diff, missing_emp, counter
+        return diff, missing_emp, counter, users
 
     @staticmethod
     def _format_user(discord_user: discord.Member, ldap_user: ldap.LDAPUser | None) -> str:
@@ -429,7 +427,7 @@ class LDAP(commands.Cog):
     @ldap_group.command(name="sync")
     async def sync(self, ctx: commands.Context) -> None:
         """List users found in the LDAP directory."""
-        diff, missing_emp, counts = await self.get_user_diff()
+        diff, missing_emp, counts, _ = await self.get_user_diff()
 
         add_users = counts[LDAPSyncAction.ADD]
         remove_users = counts[LDAPSyncAction.REMOVE]


### PR DESCRIPTION
Container was getting OOM killed (800Mi limit). Two causes identified:

- `all_github_identities()` was calling `a_get_user()` for every Keycloak user to read `federatedIdentities`, but the `/users` list endpoint doesn't populate that field. This meant we were fetching the full `UserRepresentation` (including heavy `userProfileMetadata`) for every user, every 5 minutes. Switched to the dedicated `/users/{id}/federated-identity` endpoint which returns only the identity records.

- `_handle_left_users` was calling `ldap.find_users()` independently, even though `get_user_diff` had already fetched the same data in the same sync cycle. The already-fetched list is now passed through instead.