### PR TITLE
fix: resolve steady RAM growth from per-call aiohttp sessions and missing cog cleanup

### DIFF
--- a/arthur/apis/github.py
+++ b/arthur/apis/github.py
@@ -19,255 +19,245 @@ HEADERS = {
 }
 
 
-async def remove_org_member(username: str) -> None:
+async def remove_org_member(username: str, session: aiohttp.ClientSession) -> None:
     """Remove a user from the GitHub organisation."""
     if username.lower() in {"chrislovering", "jb3", "jchristgit"}:
         msg = "I must not harm my masters. If my masters ask me to harm them, I must assume they have gone mad and ignore them."
         raise GitHubError(msg)
 
-    async with aiohttp.ClientSession() as session:
-        endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/members/{username}"
+    endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/members/{username}"
 
-        async with session.delete(endpoint, headers=HEADERS) as resp:
-            try:
-                resp.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                if e.status == HTTPStatus.NOT_FOUND:
-                    msg = f"Team or user not found in the org: {e.message}"
-                    raise GitHubError(msg)
-                if e.status == HTTPStatus.FORBIDDEN:
-                    msg = f"Forbidden: {e.message}"
-                    raise GitHubError(msg)
-
-                msg = f"Unexpected error: {e.message}"
+    async with session.delete(endpoint, headers=HEADERS) as resp:
+        try:
+            resp.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            if e.status == HTTPStatus.NOT_FOUND:
+                msg = f"Team or user not found in the org: {e.message}"
+                raise GitHubError(msg)
+            if e.status == HTTPStatus.FORBIDDEN:
+                msg = f"Forbidden: {e.message}"
                 raise GitHubError(msg)
 
+            msg = f"Unexpected error: {e.message}"
+            raise GitHubError(msg)
 
-async def add_org_member(username: str) -> None:
+
+async def add_org_member(username: str, session: aiohttp.ClientSession) -> None:
     """Add a user to the GitHub organisation."""
-    async with aiohttp.ClientSession() as session:
-        endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/memberships/{username}"
-        async with session.put(endpoint, headers=HEADERS, json={"role": "member"}) as response:
-            try:
-                response.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                if e.status == HTTPStatus.NOT_FOUND:
-                    msg = f"User not found: {e.message}"
-                    raise GitHubError(msg)
-                if e.status == HTTPStatus.FORBIDDEN:
-                    msg = f"Forbidden: {e.message}"
-                    raise GitHubError(msg)
-
-                msg = f"Unexpected error: {e.message}"
+    endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/memberships/{username}"
+    async with session.put(endpoint, headers=HEADERS, json={"role": "member"}) as response:
+        try:
+            response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            if e.status == HTTPStatus.NOT_FOUND:
+                msg = f"User not found: {e.message}"
+                raise GitHubError(msg)
+            if e.status == HTTPStatus.FORBIDDEN:
+                msg = f"Forbidden: {e.message}"
                 raise GitHubError(msg)
 
+            msg = f"Unexpected error: {e.message}"
+            raise GitHubError(msg)
 
-async def get_username_for_user_id(user_id: str) -> str | None:
+
+async def get_username_for_user_id(user_id: str, session: aiohttp.ClientSession) -> str | None:
     """Resolve a GitHub login from an account ID."""
-    async with aiohttp.ClientSession() as session:
-        endpoint = f"https://api.github.com/user/{user_id}"
-        async with session.get(endpoint, headers=HEADERS) as response:
-            try:
-                response.raise_for_status()
-                data = await response.json()
-            except aiohttp.ClientResponseError as e:
-                if e.status == HTTPStatus.NOT_FOUND:
-                    return None
+    endpoint = f"https://api.github.com/user/{user_id}"
+    async with session.get(endpoint, headers=HEADERS) as response:
+        try:
+            response.raise_for_status()
+            data = await response.json()
+        except aiohttp.ClientResponseError as e:
+            if e.status == HTTPStatus.NOT_FOUND:
+                return None
 
-                msg = f"Failed to resolve GitHub user ID {user_id}: {e.message}"
-                raise GitHubError(msg)
+            msg = f"Failed to resolve GitHub user ID {user_id}: {e.message}"
+            raise GitHubError(msg)
 
     return data.get("login")
 
 
-async def list_organisation_member_identities() -> dict[str, str]:
+async def list_organisation_member_identities(session: aiohttp.ClientSession) -> dict[str, str]:
     """List all organisation members as a mapping of account ID to login."""
     members = {}
     page = 1
     per_page = 100
 
-    async with aiohttp.ClientSession() as session:
-        while True:
-            endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/members?per_page={per_page}&page={page}"
-            async with session.get(endpoint, headers=HEADERS) as response:
-                try:
-                    response.raise_for_status()
-                    data = await response.json()
-                    members.update(
-                        {
-                            str(member["id"]): member["login"]
-                            for member in data
-                            if member.get("id") and member.get("login")
-                        }
-                    )
-                    if len(data) < per_page:
-                        break
-                    page += 1
-                except aiohttp.ClientResponseError as e:
-                    msg = f"Failed to list organisation member identities: {e.message}"
-                    raise GitHubError(msg)
+    while True:
+        endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/members?per_page={per_page}&page={page}"
+        async with session.get(endpoint, headers=HEADERS) as response:
+            try:
+                response.raise_for_status()
+                data = await response.json()
+                members.update(
+                    {
+                        str(member["id"]): member["login"]
+                        for member in data
+                        if member.get("id") and member.get("login")
+                    }
+                )
+                if len(data) < per_page:
+                    break
+                page += 1
+            except aiohttp.ClientResponseError as e:
+                msg = f"Failed to list organisation member identities: {e.message}"
+                raise GitHubError(msg)
 
     return members
 
 
-async def list_pending_org_invitations() -> set[str]:
+async def list_pending_org_invitations(session: aiohttp.ClientSession) -> set[str]:
     """List GitHub logins with pending organisation invitations."""
     pending = set()
     page = 1
     per_page = 100
 
-    async with aiohttp.ClientSession() as session:
-        while True:
-            endpoint = (
-                f"https://api.github.com/orgs/{CONFIG.github_org}/invitations"
-                f"?per_page={per_page}&page={page}"
-            )
-            async with session.get(endpoint, headers=HEADERS) as response:
-                try:
-                    response.raise_for_status()
-                    data = await response.json()
-                    for invitation in data:
-                        login = invitation.get("login") or invitation.get("invitee", {}).get(
-                            "login"
-                        )
-                        if login:
-                            pending.add(login)
+    while True:
+        endpoint = (
+            f"https://api.github.com/orgs/{CONFIG.github_org}/invitations"
+            f"?per_page={per_page}&page={page}"
+        )
+        async with session.get(endpoint, headers=HEADERS) as response:
+            try:
+                response.raise_for_status()
+                data = await response.json()
+                for invitation in data:
+                    login = invitation.get("login") or invitation.get("invitee", {}).get("login")
+                    if login:
+                        pending.add(login)
 
-                    if len(data) < per_page:
-                        break
-                    page += 1
-                except aiohttp.ClientResponseError as e:
-                    msg = f"Failed to list pending organisation invitations: {e.message}"
-                    raise GitHubError(msg)
+                if len(data) < per_page:
+                    break
+                page += 1
+            except aiohttp.ClientResponseError as e:
+                msg = f"Failed to list pending organisation invitations: {e.message}"
+                raise GitHubError(msg)
 
     return pending
 
 
-async def list_failed_org_invitations() -> set[str]:
+async def list_failed_org_invitations(session: aiohttp.ClientSession) -> set[str]:
     """List GitHub logins with failed organisation invitations."""
     failed = set()
     page = 1
     per_page = 100
 
-    async with aiohttp.ClientSession() as session:
-        while True:
-            endpoint = (
-                f"https://api.github.com/orgs/{CONFIG.github_org}/failed_invitations"
-                f"?per_page={per_page}&page={page}"
-            )
-            async with session.get(endpoint, headers=HEADERS) as response:
-                try:
-                    response.raise_for_status()
-                    data = await response.json()
-                    for invitation in data:
-                        login = invitation.get("login") or invitation.get("invitee", {}).get(
-                            "login"
-                        )
-                        if login:
-                            failed.add(login)
+    while True:
+        endpoint = (
+            f"https://api.github.com/orgs/{CONFIG.github_org}/failed_invitations"
+            f"?per_page={per_page}&page={page}"
+        )
+        async with session.get(endpoint, headers=HEADERS) as response:
+            try:
+                response.raise_for_status()
+                data = await response.json()
+                for invitation in data:
+                    login = invitation.get("login") or invitation.get("invitee", {}).get("login")
+                    if login:
+                        failed.add(login)
 
-                    if len(data) < per_page:
-                        break
-                    page += 1
-                except aiohttp.ClientResponseError as e:
-                    if e.status == HTTPStatus.NOT_FOUND:
-                        # Some org/API versions may not expose failed invitations.
-                        return failed
+                if len(data) < per_page:
+                    break
+                page += 1
+            except aiohttp.ClientResponseError as e:
+                if e.status == HTTPStatus.NOT_FOUND:
+                    # Some org/API versions may not expose failed invitations.
+                    return failed
 
-                    msg = f"Failed to list failed organisation invitations: {e.message}"
-                    raise GitHubError(msg)
+                msg = f"Failed to list failed organisation invitations: {e.message}"
+                raise GitHubError(msg)
 
     return failed
 
 
-async def add_member_to_team(username: str, github_team_slug: str) -> None:
+async def add_member_to_team(
+    username: str, github_team_slug: str, session: aiohttp.ClientSession
+) -> None:
     """Add a user to a GitHub team."""
-    async with aiohttp.ClientSession() as session:
-        endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/teams/{github_team_slug}/memberships/{username}"
-        async with session.put(endpoint, headers=HEADERS) as response:
-            try:
-                response.raise_for_status()
-                return await response.json()
-            except aiohttp.ClientResponseError as e:
-                if e.status == HTTPStatus.NOT_FOUND:
-                    msg = f"Team or user not found: {e.message}"
-                    raise GitHubError(msg)
-                if e.status == HTTPStatus.FORBIDDEN:
-                    msg = f"Forbidden: {e.message}"
-                    raise GitHubError(msg)
-                if e.status == HTTPStatus.UNPROCESSABLE_ENTITY:
-                    msg = "Cannot add organisation as a team member"
-                    raise GitHubError(msg)
-
-                msg = f"Unexpected error: {e.message}"
+    endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/teams/{github_team_slug}/memberships/{username}"
+    async with session.put(endpoint, headers=HEADERS) as response:
+        try:
+            response.raise_for_status()
+            return await response.json()
+        except aiohttp.ClientResponseError as e:
+            if e.status == HTTPStatus.NOT_FOUND:
+                msg = f"Team or user not found: {e.message}"
+                raise GitHubError(msg)
+            if e.status == HTTPStatus.FORBIDDEN:
+                msg = f"Forbidden: {e.message}"
+                raise GitHubError(msg)
+            if e.status == HTTPStatus.UNPROCESSABLE_ENTITY:
+                msg = "Cannot add organisation as a team member"
                 raise GitHubError(msg)
 
+            msg = f"Unexpected error: {e.message}"
+            raise GitHubError(msg)
 
-async def list_team_members(github_team_slug: str) -> list[str]:
+
+async def list_team_members(github_team_slug: str, session: aiohttp.ClientSession) -> list[str]:
     """List all members of a GitHub team, and handle pagination."""
     members = []
     page = 1
     per_page = 100
 
-    async with aiohttp.ClientSession() as session:
-        while True:
-            endpoint = (
-                f"https://api.github.com/orgs/{CONFIG.github_org}/teams/{github_team_slug}"
-                f"/members?per_page={per_page}&page={page}"
-            )
-            async with session.get(endpoint, headers=HEADERS) as response:
-                try:
-                    response.raise_for_status()
-                    data = await response.json()
-                    members.extend([member["login"] for member in data])
-                    if len(data) < per_page:
-                        break
-                    page += 1
-                except aiohttp.ClientResponseError as e:
-                    msg = f"Failed to list team members for {github_team_slug}: {e.message}"
-                    raise GitHubError(msg)
+    while True:
+        endpoint = (
+            f"https://api.github.com/orgs/{CONFIG.github_org}/teams/{github_team_slug}"
+            f"/members?per_page={per_page}&page={page}"
+        )
+        async with session.get(endpoint, headers=HEADERS) as response:
+            try:
+                response.raise_for_status()
+                data = await response.json()
+                members.extend([member["login"] for member in data])
+                if len(data) < per_page:
+                    break
+                page += 1
+            except aiohttp.ClientResponseError as e:
+                msg = f"Failed to list team members for {github_team_slug}: {e.message}"
+                raise GitHubError(msg)
 
     return members
 
 
-async def remove_member_from_team(username: str, github_team_slug: str) -> None:
+async def remove_member_from_team(
+    username: str, github_team_slug: str, session: aiohttp.ClientSession
+) -> None:
     """Remove a user from a GitHub team."""
-    async with aiohttp.ClientSession() as session:
-        endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/teams/{github_team_slug}/memberships/{username}"
-        async with session.delete(endpoint, headers=HEADERS) as response:
-            try:
-                response.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                if e.status == HTTPStatus.NOT_FOUND:
-                    msg = f"Team or user not found: {e.message}"
-                    raise GitHubError(msg)
-                if e.status == HTTPStatus.FORBIDDEN:
-                    msg = f"Forbidden: {e.message}"
-                    raise GitHubError(msg)
-
-                msg = f"Unexpected error: {e.message}"
+    endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/teams/{github_team_slug}/memberships/{username}"
+    async with session.delete(endpoint, headers=HEADERS) as response:
+        try:
+            response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            if e.status == HTTPStatus.NOT_FOUND:
+                msg = f"Team or user not found: {e.message}"
+                raise GitHubError(msg)
+            if e.status == HTTPStatus.FORBIDDEN:
+                msg = f"Forbidden: {e.message}"
                 raise GitHubError(msg)
 
+            msg = f"Unexpected error: {e.message}"
+            raise GitHubError(msg)
 
-async def list_organisation_members() -> list[str]:
+
+async def list_organisation_members(session: aiohttp.ClientSession) -> list[str]:
     """List all members of the GitHub organisation, and handle pagination."""
     members = []
     page = 1
     per_page = 100
 
-    async with aiohttp.ClientSession() as session:
-        while True:
-            endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/members?per_page={per_page}&page={page}"
-            async with session.get(endpoint, headers=HEADERS) as response:
-                try:
-                    response.raise_for_status()
-                    data = await response.json()
-                    members.extend([member["login"] for member in data])
-                    if len(data) < per_page:
-                        break
-                    page += 1
-                except aiohttp.ClientResponseError as e:
-                    msg = f"Failed to list organisation members: {e.message}"
-                    raise GitHubError(msg)
+    while True:
+        endpoint = f"https://api.github.com/orgs/{CONFIG.github_org}/members?per_page={per_page}&page={page}"
+        async with session.get(endpoint, headers=HEADERS) as response:
+            try:
+                response.raise_for_status()
+                data = await response.json()
+                members.extend([member["login"] for member in data])
+                if len(data) < per_page:
+                    break
+                page += 1
+            except aiohttp.ClientResponseError as e:
+                msg = f"Failed to list organisation members: {e.message}"
+                raise GitHubError(msg)
 
     return members

--- a/arthur/exts/directory/ldap.py
+++ b/arthur/exts/directory/ldap.py
@@ -155,6 +155,10 @@ class LDAP(commands.Cog):
         self.bot = bot
         self.sync_users.start()
 
+    async def cog_unload(self) -> None:
+        """Cancel background tasks on unload."""
+        self.sync_users.cancel()
+
     @tasks.loop(minutes=10)
     async def sync_users(self) -> None:
         """Sync users with the LDAP directory."""

--- a/arthur/exts/fun/motivation.py
+++ b/arthur/exts/fun/motivation.py
@@ -29,6 +29,11 @@ class Motivation(commands.Cog):
         if CONFIG.youtube_api_key:
             self.send_daily_mission.start()
 
+    async def cog_unload(self) -> None:
+        """Cancel background tasks on unload."""
+        self.send_daily_motivation.cancel()
+        self.send_daily_mission.cancel()
+
     @tasks.loop(time=time(hour=12, minute=30, tzinfo=UTC))
     async def send_daily_mission(self) -> None:
         """Send the daily mission to the team."""

--- a/arthur/exts/fun/numbers.py
+++ b/arthur/exts/fun/numbers.py
@@ -37,6 +37,7 @@ class Numbers(commands.GroupCog):
 
     async def cog_unload(self) -> None:
         """Disconnect from devops channel on cog unload."""
+        self.devops_vc_check.cancel()
         if self.devops_vc and (vc := self.devops_vc.guild.voice_client):
             await vc.disconnect(force=True)
 

--- a/arthur/exts/fun/quotes.py
+++ b/arthur/exts/fun/quotes.py
@@ -30,6 +30,7 @@ class QuotesCog(commands.Cog):
 
     async def cog_load(self) -> None:
         """Fetch the quotes to be used."""
+        self.quotes.clear()
         try:
             async with self.bot.http_session.get(
                 "http://quotes.cat-v.org/programming/"

--- a/arthur/exts/github/management.py
+++ b/arthur/exts/github/management.py
@@ -26,6 +26,8 @@ from arthur.constants import LDAP_ROLE_MAPPING
 from arthur.log import logger
 
 if TYPE_CHECKING:
+    import aiohttp
+
     from arthur.bot import KingArthurTheTerrible
 
 
@@ -221,13 +223,13 @@ class GitHubManagement(Cog):
     async def _fetch_common_info(self) -> SyncCommonInfo:
         """Fetch common data needed for both GitHub org and team synchronisation."""
         keycloak_identities = await all_github_identities()
-        github_org_members = await list_organisation_member_identities()
+        github_org_members = await list_organisation_member_identities(self.bot.http_session)
         resolved_keycloak_logins_by_id = await self._resolve_logins_by_user_id(
             keycloak_identities,
             github_org_members,
         )
-        pending_invitations = await list_pending_org_invitations()
-        failed_invitations = await list_failed_org_invitations()
+        pending_invitations = await list_pending_org_invitations(self.bot.http_session)
+        failed_invitations = await list_failed_org_invitations(self.bot.http_session)
 
         return SyncCommonInfo(
             keycloak_identities=keycloak_identities,
@@ -251,7 +253,7 @@ class GitHubManagement(Cog):
         }
 
         for user_id in sorted(unresolved_user_ids):
-            resolved_login = await get_username_for_user_id(user_id)
+            resolved_login = await get_username_for_user_id(user_id, self.bot.http_session)
             if resolved_login:
                 resolved_keycloak_logins_by_id[user_id] = resolved_login
                 continue
@@ -462,12 +464,13 @@ class GitHubManagement(Cog):
         usernames: list[str],
         keycloak_identities: dict[str, dict[str, str]],
         resolved_logins_by_user_id: dict[str, str],
+        session: aiohttp.ClientSession,
     ) -> list[str]:
         """Apply organisation additions and return successfully added logins."""
         added = []
         for username in usernames:
             try:
-                await add_org_member(username)
+                await add_org_member(username, session)
                 added.append(username)
                 keycloak_username = self._get_keycloak_username_for_github_username(
                     username,
@@ -480,12 +483,14 @@ class GitHubManagement(Cog):
 
         return added
 
-    async def _apply_org_removals(self, usernames: list[str]) -> list[str]:
+    async def _apply_org_removals(
+        self, usernames: list[str], session: aiohttp.ClientSession
+    ) -> list[str]:
         """Apply organisation removals and return successfully removed logins."""
         removed = []
         for username in usernames:
             try:
-                await remove_org_member(username)
+                await remove_org_member(username, session)
                 removed.append(username)
             except GitHubError as e:
                 logger.opt(exception=e).error(f"GitHub: Failed to remove {username} from org")
@@ -608,8 +613,9 @@ class GitHubManagement(Cog):
             plan.diff.to_add,
             common_info.keycloak_identities,
             common_info.resolved_logins_by_user_id,
+            self.bot.http_session,
         )
-        removed = await self._apply_org_removals(plan.diff.to_remove)
+        removed = await self._apply_org_removals(plan.diff.to_remove, self.bot.http_session)
 
         return added, removed
 
@@ -634,7 +640,7 @@ class GitHubManagement(Cog):
                 if member.uid in keycloak_to_github
             ]
 
-            current_team_members = await list_team_members(github_team_slug)
+            current_team_members = await list_team_members(github_team_slug, self.bot.http_session)
 
             plan = self._build_team_sync_plan(
                 team_slug=github_team_slug,
@@ -646,7 +652,7 @@ class GitHubManagement(Cog):
 
             for username in plan.diff.to_add:
                 try:
-                    await add_member_to_team(username, github_team_slug)
+                    await add_member_to_team(username, github_team_slug, self.bot.http_session)
                     added.append(f"{username} -> {github_team_slug}")
                 except GitHubError as e:
                     logger.opt(exception=e).error(
@@ -655,7 +661,7 @@ class GitHubManagement(Cog):
 
             for username in plan.diff.to_remove:
                 try:
-                    await remove_member_from_team(username, github_team_slug)
+                    await remove_member_from_team(username, github_team_slug, self.bot.http_session)
                     removed.append(f"{username} -> {github_team_slug}")
                 except GitHubError as e:
                     logger.opt(exception=e).error(

--- a/arthur/exts/grafana/ldap_team_sync.py
+++ b/arthur/exts/grafana/ldap_team_sync.py
@@ -34,6 +34,10 @@ class GrafanaLDAPTeamSync(commands.Cog):
         self.bot = bot
         self.sync_ldap_grafana_teams.start()
 
+    async def cog_unload(self) -> None:
+        """Cancel background tasks on unload."""
+        self.sync_ldap_grafana_teams.cancel()
+
     async def _add_missing_members(
         self,
         grafana_team_id: int,

--- a/arthur/exts/systems/system_information.py
+++ b/arthur/exts/systems/system_information.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Literal, TYPE_CHECKING
 from urllib import parse
 
-import aiohttp
 from discord import File, Member, Message
 from discord.ext import tasks
 from discord.ext.commands import Cog, Context, Converter, command
@@ -68,7 +67,7 @@ class SystemInformation(Cog):
         """Fetch the file contents of the given filename, starting from ``/``."""
         if name not in self.cached_resources:
             url = BASE_RESOURCE.format(name)
-            async with aiohttp.ClientSession() as session, session.get(url) as resp:
+            async with self.bot.http_session.get(url) as resp:
                 self.cached_resources[name] = await resp.text()
         return self.cached_resources[name]
 
@@ -178,7 +177,7 @@ class SystemInformation(Cog):
 
             await ctx.message.attachments[0].save(image_bytes)
         else:
-            async with aiohttp.ClientSession() as session, session.get(image_url) as resp:
+            async with self.bot.http_session.get(image_url) as resp:
                 if resp.ok:
                     image_bytes.write(await resp.read())
                     image_bytes.seek(0)


### PR DESCRIPTION
The bot was showing a consistent ~20MB/hour RAM increase. Root cause was `github.py` creating a new `aiohttp.ClientSession` for every API call — `sync_github_org` fires every 5 minutes and calls 5–10 of these per run. Each session leaves behind a TCP connector, SSL context, and cookie jar that Python never returns to the OS, ratcheting the heap upward on every cycle.

All `github.py` functions now accept a `session` parameter; `management.py` passes `self.bot.http_session`. The same per-request session pattern was also fixed in `system_information.py` (`fetch_resource` and `face`).

Secondary fixes included while investigating:
- `motivation`, `ldap`, `ldap_team_sync`, `numbers`: add `cog_unload` cancellation for `tasks.loop` background tasks that were leaking on cog reload
- `quotes`: `cog_load` was appending to `self.quotes` without clearing first, doubling the list on every reload