### PR TITLE
Run under tini init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
     imagemagick \
     libldap2 \
+    tini \
     && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*
 
 # Copy a static build of ffmpeg from the ffmpeg stage.
@@ -55,5 +56,5 @@ WORKDIR /app
 COPY . .
 ENV PATH="/opt/king-arthur/.venv/bin:$PATH"
 
-ENTRYPOINT ["python"]
-CMD ["-m", "arthur"]
+ENTRYPOINT ["tini", "--"]
+CMD ["python", "-m", "arthur"]


### PR DESCRIPTION
This allows for attaching to the python process itself, since the linux kernel blocks PTRACE_ATTACH for pid 1.

tini also comes with some other nice benefits like reaping zombie processes and signal forwarding