### PR TITLE
Command output via email

### DIFF
--- a/arthur/apis/email/__init__.py
+++ b/arthur/apis/email/__init__.py
@@ -1,0 +1,5 @@
+"""Email API utilities."""
+
+from .smtp import send_email
+
+__all__ = ["send_email"]

--- a/arthur/apis/email/smtp.py
+++ b/arthur/apis/email/smtp.py
@@ -1,0 +1,41 @@
+"""API utilities for sending e-mail via SMTP."""
+
+import asyncio
+import smtplib
+from email.message import EmailMessage
+
+from arthur.config import CONFIG
+
+SMTP_TIMEOUT_SECONDS = 10
+
+
+def _send_email_sync(recipient: str, subject: str, body: str) -> None:
+    """Send an e-mail using the configured SMTP relay."""
+    if not all(
+        (
+            CONFIG.email_host,
+            CONFIG.email_from,
+            CONFIG.email_username,
+            CONFIG.email_password,
+        )
+    ):
+        msg = "E-mail credentials are not fully configured."
+        raise RuntimeError(msg)
+
+    message = EmailMessage()
+    message["From"] = CONFIG.email_from
+    message["To"] = recipient
+    message["Subject"] = subject
+    message.set_content(body)
+
+    with smtplib.SMTP(CONFIG.email_host, CONFIG.email_port, timeout=SMTP_TIMEOUT_SECONDS) as smtp:
+        if CONFIG.email_starttls:
+            smtp.starttls()
+
+        smtp.login(CONFIG.email_username, CONFIG.email_password.get_secret_value())
+        smtp.send_message(message)
+
+
+async def send_email(recipient: str, subject: str, body: str) -> None:
+    """Send an e-mail without blocking the event loop."""
+    await asyncio.to_thread(_send_email_sync, recipient, subject, body)

--- a/arthur/config.py
+++ b/arthur/config.py
@@ -55,6 +55,15 @@ class Config(
 
     ldap_certificate_location: pydantic.FilePath | None = None
 
+    # Email
+
+    email_host: str | None = None
+    email_port: int = 587
+    email_from: str | None = None
+    email_username: str | None = None
+    email_password: pydantic.SecretStr | None = None
+    email_starttls: bool = True
+
     # Keycloak
 
     keycloak_address: pydantic.AnyUrl | None = None

--- a/arthur/exts/fun/remote_command_runner.py
+++ b/arthur/exts/fun/remote_command_runner.py
@@ -1,11 +1,39 @@
+import smtplib
 from typing import TYPE_CHECKING
 
 from discord.ext.commands import Cog, Context, command
 
+from arthur.apis.directory.ldap import find_by_discord_id
+from arthur.apis.email import send_email
 from arthur.apis.netcup.ssh import rce_as_a_service
 
 if TYPE_CHECKING:
     from arthur.bot import KingArthurTheTerrible
+
+
+MAX_MESSAGE_LENGTH = 2000
+
+
+def _format_discord_response(returncode: int, stderr: str, stdout: str) -> str:
+    """Format command output as a Discord message."""
+    return (
+        f"returncode={returncode}\n"
+        f"stderr:```{stderr or '~Empty~'}```\n"
+        f"stdout:```{stdout or '~Empty~'}```\n"
+    )
+
+
+def _format_email_response(command: str, returncode: int, stderr: str, stdout: str) -> str:
+    """Format command output as plain text for email delivery."""
+    return (
+        "King Arthur remote command output\n\n"
+        f"command: {command}\n"
+        f"returncode: {returncode}\n\n"
+        "stderr:\n"
+        f"{stderr or '~Empty~'}\n\n"
+        "stdout:\n"
+        f"{stdout or '~Empty~'}\n"
+    )
 
 
 class RemoteCommands(Cog):
@@ -26,13 +54,45 @@ class RemoteCommands(Cog):
         response = await rce_as_a_service(command)
 
         if not response.stderr and not response.stdout:
-            await ctx.send(f"Successfully ran with no output! {response.returncode = }")
+            await ctx.send(f"Successfully ran with no output! returncode={response.returncode}")
+            return
+
+        discord_message = _format_discord_response(
+            response.returncode,
+            response.stderr,
+            response.stdout,
+        )
+
+        if len(discord_message) <= MAX_MESSAGE_LENGTH:
+            await ctx.send(discord_message)
+            return
+
+        ldap_user = await find_by_discord_id(ctx.author.id)
+        if not ldap_user:
+            await ctx.send(
+                ":x: Output is too long for Discord and no LDAP user was found for your Discord ID."
+            )
+            return
+
+        recipient = f"{ldap_user.uid}@pydis.wtf"
+
+        try:
+            await send_email(
+                recipient=recipient,
+                subject=f"King Arthur command output (returncode={response.returncode})",
+                body=_format_email_response(
+                    command,
+                    response.returncode,
+                    response.stderr,
+                    response.stdout,
+                ),
+            )
+        except RuntimeError, smtplib.SMTPException, OSError:
+            await ctx.send(":x: Output is too long for Discord and sending it by e-mail failed.")
             return
 
         await ctx.send(
-            f"{response.returncode = }\n"
-            f"stderr:```{response.stderr or '~Empty~'}```\n"
-            f"stdout:```{response.stdout or '~Empty~'}```\n"
+            f":mailbox_with_mail: Output was too long for Discord, so it was sent to `{recipient}`."
         )
 
 


### PR DESCRIPTION
This pull request introduces a new email utility API and integrates it into the remote command runner. Now, if remote command output is too large for Discord, it will be sent to the user's email (if available in LDAP). The changes also add email configuration options to the application settings.

Closes #262.