### PR TITLE
Pipe stdlib logging through loguru

### DIFF
--- a/arthur/__main__.py
+++ b/arthur/__main__.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 import arthur
 from arthur.bot import KingArthurTheTerrible
 from arthur.config import CONFIG
-from arthur.log import logger, setup_sentry
+from arthur.log import logger, setup_sentry, setup_stdlib_logging
 
 
 async def main() -> None:
@@ -43,6 +43,7 @@ async def main() -> None:
 
 
 setup_sentry()
+setup_stdlib_logging()
 
 with logger.catch():
     asyncio.run(main())

--- a/arthur/log.py
+++ b/arthur/log.py
@@ -1,13 +1,41 @@
+import inspect
+import logging
 from functools import partial
 
 import loguru
 import sentry_sdk
+import sentry_sdk.integrations.logging as _sentry_logging
 from sentry_sdk.integrations.loguru import LoggingLevels, LoguruIntegration
 
 from arthur.config import CONFIG, GIT_SHA
 
 logger = loguru.logger.opt(colors=True)
 logger.opt = partial(logger.opt, colors=True)
+
+
+class _InterceptHandler(logging.Handler):
+    """Intercept standard logging records and forward them to loguru."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = loguru.logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find the actual line that logged this message
+        # skip loguru internal frames & sentry as it patches the logging module
+        _skip = {logging.__file__, _sentry_logging.__file__}
+        frame, depth = inspect.currentframe(), 0
+        while frame and (depth == 0 or frame.f_code.co_filename in _skip):
+            frame = frame.f_back
+            depth += 1
+
+        loguru.logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+def setup_stdlib_logging() -> None:
+    """Route standard library logging through loguru."""
+    logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
 
 
 def setup_sentry() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ license = {text = "MIT"}
 requires-python = "~=3.14.0"
 dependencies = [
     "pydis-core[voice]==11.9.2",
-    "audioop-lts==0.2.2",
     "asyncssh==2.22.0",
+    "audioop-lts==0.2.2",
     "beautifulsoup4==4.14.3",
     "humanize==4.15.0",
     "jishaku==2.6.3",
     "kubernetes-asyncio==35.0.1",
     "loguru==0.7.3",
-    "memray==1.19.3",
+    "memray==1.19.3; sys_platform != 'win32'",
     "pydantic==2.12.5",
     "pydantic-settings==2.13.1",
     "python-freeipa==1.0.10",

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ dependencies = [
     { name = "jishaku" },
     { name = "kubernetes-asyncio" },
     { name = "loguru" },
-    { name = "memray" },
+    { name = "memray", marker = "sys_platform != 'win32'" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pydis-core", extra = ["voice"] },
@@ -619,7 +619,7 @@ requires-dist = [
     { name = "jishaku", specifier = "==2.6.3" },
     { name = "kubernetes-asyncio", specifier = "==35.0.1" },
     { name = "loguru", specifier = "==0.7.3" },
-    { name = "memray", specifier = "==1.19.3" },
+    { name = "memray", marker = "sys_platform != 'win32'", specifier = "==1.19.3" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = "==2.13.1" },
     { name = "pydis-core", extras = ["voice"], specifier = "==11.9.2" },
@@ -712,9 +712,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
     { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
     { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
     { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
     { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
@@ -723,9 +720,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
     { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
     { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Routes stdlib `logging` calls through loguru so all log output is unified. The `InterceptHandler` also skips sentry's monkey-patched `callHandlers` so the displayed call site resolves correctly.

Also restricts `memray` to non-Windows platforms to unblock local development.